### PR TITLE
Fix compilation warning on MacOS - use snprintf

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Intel and ARM supported
 
 ## Install
 
-```go get github.com/adrium/goheif```
+```go get github.com/raducrisan1/goheif```
 
 - Code Sample
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/raducrisan1/goheif
+
+go 1.19
+
+require github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd h1:CmH9+J6ZSsIjUK3dcGsnCnO41eRBOnY12zwkn5qVwgc=
+github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=

--- a/goheif.go
+++ b/goheif.go
@@ -8,8 +8,8 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/adrium/goheif/heif"
-	"github.com/adrium/goheif/libde265"
+	"github.com/raducrisan1/goheif/heif"
+	"github.com/raducrisan1/goheif/libde265"
 )
 
 // SafeEncoding uses more memory but seems to make

--- a/heic2jpg/main.go
+++ b/heic2jpg/main.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/adrium/goheif"
+	"github.com/raducrisan1/goheif"
 )
 
 // Skip Writer for exif writing

--- a/heif/heif.go
+++ b/heif/heif.go
@@ -27,7 +27,7 @@ import (
 	"io"
 	"log"
 
-	"github.com/adrium/goheif/heif/bmff"
+	"github.com/raducrisan1/goheif/heif/bmff"
 )
 
 // File represents a HEIF file.

--- a/libde265/libde265/deblock.cc
+++ b/libde265/libde265/deblock.cc
@@ -905,7 +905,7 @@ public:
   virtual void work();
   virtual std::string name() const {
     char buf[100];
-    sprintf(buf,"deblock-%d",ctb_y);
+    snprintf(buf,sizeof(buf), "deblock-%d",ctb_y);
     return buf;
   }
 };
@@ -1036,7 +1036,7 @@ void apply_deblocking_filter(de265_image* img) // decoder_context* ctx)
       }
 #if 0
       char buf[1000];
-      sprintf(buf,"lf-after-V-%05d.yuv", ctx->img->PicOrderCntVal);
+      snprintf(buf,sizeof(buf),"lf-after-V-%05d.yuv", ctx->img->PicOrderCntVal);
       write_picture_to_file(ctx->img, buf);
 #endif
 
@@ -1051,7 +1051,7 @@ void apply_deblocking_filter(de265_image* img) // decoder_context* ctx)
       }
 
 #if 0
-      sprintf(buf,"lf-after-H-%05d.yuv", ctx->img->PicOrderCntVal);
+      snprintf(buf,sizeof(buf),"lf-after-H-%05d.yuv", ctx->img->PicOrderCntVal);
       write_picture_to_file(ctx->img, buf);
 #endif
     }

--- a/libde265/libde265/decctx.cc
+++ b/libde265/libde265/decctx.cc
@@ -1872,7 +1872,7 @@ void decoder_context::run_postprocessing_filters_sequential(de265_image* img)
 {
 #if SAVE_INTERMEDIATE_IMAGES
     char buf[1000];
-    sprintf(buf,"pre-lf-%05d.yuv", img->PicOrderCntVal);
+    snprintf(buf,sizeof(buf),"pre-lf-%05d.yuv", img->PicOrderCntVal);
     write_picture_to_file(img, buf);
 #endif
 
@@ -1881,7 +1881,7 @@ void decoder_context::run_postprocessing_filters_sequential(de265_image* img)
     }
 
 #if SAVE_INTERMEDIATE_IMAGES
-    sprintf(buf,"pre-sao-%05d.yuv", img->PicOrderCntVal);
+    snprintf(buf,sizeof(buf),"pre-sao-%05d.yuv", img->PicOrderCntVal);
     write_picture_to_file(img, buf);
 #endif
 
@@ -1890,7 +1890,7 @@ void decoder_context::run_postprocessing_filters_sequential(de265_image* img)
     }
 
 #if SAVE_INTERMEDIATE_IMAGES
-    sprintf(buf,"sao-%05d.yuv", img->PicOrderCntVal);
+    snprintf(buf,sizeof(buf),"sao-%05d.yuv", img->PicOrderCntVal);
     write_picture_to_file(img, buf);
 #endif
 }

--- a/libde265/libde265/sao.cc
+++ b/libde265/libde265/sao.cc
@@ -393,7 +393,7 @@ public:
   virtual void work();
   virtual std::string name() const {
     char buf[100];
-    sprintf(buf,"sao-%d",ctb_y);
+    snprintf(buf,sizeof(buf),"sao-%d",ctb_y);
     return buf;
   }
 };

--- a/libde265/libde265/slice.cc
+++ b/libde265/libde265/slice.cc
@@ -4890,14 +4890,14 @@ bool initialize_CABAC_at_slice_segment_start(thread_context* tctx)
 
 std::string thread_task_ctb_row::name() const {
   char buf[100];
-  sprintf(buf,"ctb-row-%d",debug_startCtbRow);
+  snprintf(buf,sizeof(buf),"ctb-row-%d",debug_startCtbRow);
   return buf;
 }
 
 
 std::string thread_task_slice_segment::name() const {
   char buf[100];
-  sprintf(buf,"slice-segment-%d;%d",debug_startCtbX,debug_startCtbY);
+  snprintf(buf,sizeof(buf),"slice-segment-%d;%d",debug_startCtbX,debug_startCtbY);
   return buf;
 }
 


### PR DESCRIPTION
- was getting 'sprintf' was marked as deprecated