### PR TITLE
GO-6630 Support mdat first boxes

### DIFF
--- a/heif/bmff/bmff.go
+++ b/heif/bmff/bmff.go
@@ -56,6 +56,7 @@ type BoxType [4]byte
 var (
 	TypeFtyp = BoxType{'f', 't', 'y', 'p'}
 	TypeMeta = BoxType{'m', 'e', 't', 'a'}
+	TypeMdat = BoxType{'m', 'd', 'a', 't'}
 )
 
 func (t BoxType) String() string { return string(t[:]) }

--- a/heif/heif.go
+++ b/heif/heif.go
@@ -237,12 +237,31 @@ func (f *File) getMeta() (*BoxMeta, error) {
 	}
 	meta.FileType = pbox.(*bmff.FileTypeBox)
 
-	pbox, err = bmr.ReadAndParseBox(bmff.TypeMeta)
+	for {
+		var box bmff.Box
+		box, err = bmr.ReadBox()
+		if err != nil {
+			break
+		}
+
+		// skip mdat boxes if they are before meta
+		if box.Type() == bmff.TypeMdat {
+			continue
+		}
+
+		if box.Type() == bmff.TypeMeta {
+			pbox, err = box.Parse()
+			break
+		}
+
+		return nil, fmt.Errorf("error reading %q box: got box type %q instead", bmff.TypeMeta, box.Type())
+	}
+
 	if err != nil {
 		return nil, f.setMetaErr(err)
 	}
-	metabox := pbox.(*bmff.MetaBox)
 
+	metabox := pbox.(*bmff.MetaBox)
 	for _, box := range metabox.Children {
 		boxp, err := box.Parse()
 		if err == bmff.ErrUnknownBox {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6630/the-image-heic-format-is-broken

Include fix for HEIC images resize from original library.
In case mdat box goes first in byte representation of file adrium/goheif fails to resize image